### PR TITLE
added tests for stream controller, revamped test db access

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "concurrently \"npm run dev-mongo\" \"nodemon\" ",
     "lint-fix": "eslint . --fix",
     "lint": "eslint .",
-    "test-server": "cross-env NODE_ENV=test npx jest ./server",
+    "test-server": "cross-env NODE_ENV=test npx jest",
     "test-watch": "cross-env NODE_ENV=test npx jest --watch",
     "ts-exec": "ts-node -r tsconfig-paths/register --project ./tsconfig.json --transpile-only"
   },

--- a/server/api/auth/auth.controller.ts
+++ b/server/api/auth/auth.controller.ts
@@ -1,8 +1,7 @@
 import { RequestHandler } from 'express';
 import { BadRequestError } from 'express-response-errors';
-import jwt from 'jsonwebtoken';
 
-import { getDiscordUserAndGuilds } from 'server/lib/auth';
+import { createUserToken, getDiscordUserAndGuilds } from 'server/lib/auth';
 import log from 'server/lib/log';
 import { AUTH_COOKIE_NAME } from 'shared/constants';
 import { User } from 'shared/user';
@@ -30,7 +29,7 @@ export const login: RequestHandler<void, void, { code: string }> = async (req, r
     username: user.username,
   };
 
-  const token = jwt.sign(payload, process.env.AUTH_SECRET, { expiresIn: '7d' });
+  const token = createUserToken(payload);
 
   res.cookie(AUTH_COOKIE_NAME, token);
 

--- a/server/api/auth/auth.test.ts
+++ b/server/api/auth/auth.test.ts
@@ -45,7 +45,7 @@ describe('auth router', () => {
       const cookies: Cookie[] = res.headers['set-cookie']
         .map(setCookie.parse)
         .map((arr: Cookie[]) => arr[0]);
-      const cookie = cookies.find(cookie => cookie.name === AUTH_COOKIE_NAME);
+      const cookie = cookies.find(cookie => cookie.name === AUTH_COOKIE_NAME && !!cookie.value);
 
       const cookiePayload = jwt.decode(cookie.value);
 

--- a/server/api/stream/index.ts
+++ b/server/api/stream/index.ts
@@ -1,6 +1,7 @@
 import { AsyncRouter } from 'express-async-router';
 
 import { isAuthed, isHost } from 'server/middleware/isAuthed';
+import { validateMongoObjectId } from 'server/middleware/validateMongoObjectId';
 
 import { postStream, getStream, deleteStream } from './stream.controller';
 const streamRouter = AsyncRouter();
@@ -10,7 +11,7 @@ streamRouter.use(isAuthed());
 // just / is more restful because endpoint will look like: POST /api/stream/
 // (which is descriptive enough)
 streamRouter.post('/', isHost(), postStream);
-streamRouter.get('/', getStream);
-streamRouter.delete('/', isHost(), deleteStream);
+streamRouter.get('/:id', validateMongoObjectId('params', 'id'), getStream);
+streamRouter.delete('/:id', validateMongoObjectId('params', 'id'), isHost(), deleteStream);
 
 export default streamRouter;

--- a/server/api/stream/stream.controller.ts
+++ b/server/api/stream/stream.controller.ts
@@ -4,9 +4,17 @@ import { startStream } from 'server/lib/ivs';
 
 export const postStream: RequestHandler = async (req, res) => {
   const { channel, streamKey } = await startStream();
+
+  //object returned contains insertedId param, consumed below
+  const stream = await req.db.Streams.insertOne({
+    arn: channel.arn,
+    createdBy: req.user.id,
+  });
+
   res.json({
     ingestEndpoint: channel.ingestEndpoint,
     streamKey: streamKey.value,
+    streamId: stream.insertedId,
   });
 };
 

--- a/server/api/stream/stream.controller.ts
+++ b/server/api/stream/stream.controller.ts
@@ -1,8 +1,17 @@
 import { RequestHandler } from 'express';
+import { BadRequestError } from 'express-response-errors';
 
 import { startStream } from 'server/lib/ivs';
 
 export const postStream: RequestHandler = async (req, res) => {
+  const existing = await req.db.Streams.findOne({
+    createdBy: req.user.id,
+  });
+
+  if (existing) {
+    throw new BadRequestError('You already have a stream running');
+  }
+
   const { channel, streamKey } = await startStream();
 
   //object returned contains insertedId param, consumed below

--- a/server/api/stream/stream.controller.ts
+++ b/server/api/stream/stream.controller.ts
@@ -1,7 +1,8 @@
+import { ObjectId } from 'bson';
 import { RequestHandler } from 'express';
-import { BadRequestError } from 'express-response-errors';
+import { BadRequestError, NotFoundError } from 'express-response-errors';
 
-import { startStream } from 'server/lib/ivs';
+import { getStreamInfo, endStream, startStream } from 'server/lib/ivs';
 
 export const postStream: RequestHandler = async (req, res) => {
   const existing = await req.db.Streams.findOne({
@@ -27,10 +28,20 @@ export const postStream: RequestHandler = async (req, res) => {
   });
 };
 
-export const getStream: RequestHandler = (req, res) => {
-  res.json({ message: 'This is a test!' });
+export const getStream: RequestHandler = async (req, res) => {
+  const stream = await req.db.Streams.findOne({ _id: new ObjectId(req.params.id) });
+  if (stream === null) {
+    throw new NotFoundError('No stream found for provided id.');
+  }
+  const info = await getStreamInfo(stream.arn);
+  res.json({ playbackUrl: info.channel.channel.playbackUrl });
 };
 
-export const deleteStream: RequestHandler = (req, res) => {
-  res.json({ message: 'This is a test!' });
+export const deleteStream: RequestHandler = async (req, res) => {
+  const stream = await req.db.Streams.findOne({ _id:  new ObjectId(req.params.id) });
+
+  await endStream(stream.arn);
+  await req.db.Streams.findOneAndDelete({ _id: new ObjectId(req.params.id) });
+
+  res.status(204);
 };

--- a/server/api/stream/stream.test.ts
+++ b/server/api/stream/stream.test.ts
@@ -1,4 +1,9 @@
-import { CreateChannelCommandOutput, DeleteChannelCommandOutput, GetChannelCommandOutput, GetStreamKeyCommandOutput } from '@aws-sdk/client-ivs';
+import {
+  CreateChannelCommandOutput,
+  DeleteChannelCommandOutput,
+  GetChannelCommandOutput,
+  GetStreamKeyCommandOutput,
+} from '@aws-sdk/client-ivs';
 import { ObjectId } from 'bson';
 
 import * as ivsLib from 'server/lib/ivs';
@@ -79,6 +84,18 @@ describe('stream router', () => {
       server.login(viewer);
       const res = await server.exec.post('/api/stream/');
       expect(res.status).toBe(403);
+    });
+
+    it('should error if the host already has a running stream', async () => {
+      server.login(host);
+
+      await server.db.Streams.insertOne({
+        arn: 'arn_123',
+        createdBy: host.id,
+      });
+
+      const res = await server.exec.post('/api/stream/');
+      expect(res.status).toBe(400);
     });
 
     it('should return the created channel arn, stream key, and create a db entry', async () => {

--- a/server/api/stream/stream.test.ts
+++ b/server/api/stream/stream.test.ts
@@ -1,0 +1,75 @@
+import { CreateChannelCommandOutput } from '@aws-sdk/client-ivs';
+
+import * as ivsLib from 'server/lib/ivs';
+import TestServer from 'server/test/server';
+import { User } from 'shared/user';
+
+describe('stream router', () => {
+  let server: TestServer;
+
+  //simulating two users with different perms
+  const host: User = {
+    id: '123',
+    username: 'host#123',
+  };
+  const viewer: User = {
+    id: '456',
+    username: 'viewer#123',
+  };
+
+  const mockedStartStreamResponse = {
+    channel: {
+      arn: 'arn_123',
+      ingestEndpoint: 'stream.com',
+    },
+    streamKey: { value: 'sk_123' },
+  } as CreateChannelCommandOutput;
+
+  beforeAll(async () => {
+    server = new TestServer();
+    await server.init('stream-api');
+    //making sure there is a host in the db
+    //since there is middleware checking if there is a host
+    await server.db.AllowedHosts.insertOne({
+      discordId: host.id,
+      username: host.username,
+    });
+
+    //hijacks startStream method in ivslib
+    //and returns mockResolvedValue when it is called
+    jest.spyOn(ivsLib, 'startStream').mockResolvedValue(mockedStartStreamResponse);
+  });
+
+  afterAll(async () => {
+    await server.destroy();
+    //resets mocks once done, because test suites should be independent
+    jest.restoreAllMocks();
+  });
+
+  describe('POST /', () => {
+    it('should error if not logged in', async () => {
+      server.logout();
+      const res = await server.exec.post('/api/stream/');
+      expect(res.status).toBe(401);
+    });
+
+    it('should error if the user is not a host', async () => {
+      server.login(viewer);
+      const res = await server.exec.post('/api/stream/');
+      expect(res.status).toBe(403);
+    });
+
+    it('should return the created channel arn, stream key, and create a db entry', async () => {
+      server.login(host);
+      const res = await server.exec.post('/api/stream/');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ingestEndpoint).toBe(mockedStartStreamResponse.channel.ingestEndpoint);
+      expect(res.body.streamKey).toBe(mockedStartStreamResponse.streamKey.value);
+
+      const stream = await server.db.Streams.findOne({ createdBy: host.id });
+
+      expect(res.body.streamId).toEqual(String(stream._id));
+    });
+  });
+});

--- a/server/api/stream/stream.test.ts
+++ b/server/api/stream/stream.test.ts
@@ -1,4 +1,5 @@
-import { CreateChannelCommandOutput } from '@aws-sdk/client-ivs';
+import { CreateChannelCommandOutput, DeleteChannelCommandOutput, GetChannelCommandOutput, GetStreamKeyCommandOutput } from '@aws-sdk/client-ivs';
+import { ObjectId } from 'bson';
 
 import * as ivsLib from 'server/lib/ivs';
 import TestServer from 'server/test/server';
@@ -25,19 +26,40 @@ describe('stream router', () => {
     streamKey: { value: 'sk_123' },
   } as CreateChannelCommandOutput;
 
+  const mockedGetStreamResponse = {
+    channel: {
+      channel: {
+        playbackUrl: 'arn_123',
+      },
+    } as GetChannelCommandOutput,
+    streamKey: {
+      streamKey: {
+        arn: 'arn_123',
+        value: 'stream_key_123',
+        channelArn: 'aaaaaa',
+      },
+    } as GetStreamKeyCommandOutput,
+  };
+
   beforeAll(async () => {
     server = new TestServer();
     await server.init('stream-api');
+
+    //hijacks startStream method in ivslib
+    //and returns mockResolvedValue when it is called
+    jest.spyOn(ivsLib, 'startStream').mockResolvedValue(mockedStartStreamResponse);
+    jest.spyOn(ivsLib, 'endStream').mockResolvedValue({} as DeleteChannelCommandOutput);
+    jest.spyOn(ivsLib, 'getStreamInfo').mockResolvedValue(mockedGetStreamResponse);
+  });
+
+  beforeEach(async () => {
+    await server.clearDb();
     //making sure there is a host in the db
     //since there is middleware checking if there is a host
     await server.db.AllowedHosts.insertOne({
       discordId: host.id,
       username: host.username,
     });
-
-    //hijacks startStream method in ivslib
-    //and returns mockResolvedValue when it is called
-    jest.spyOn(ivsLib, 'startStream').mockResolvedValue(mockedStartStreamResponse);
   });
 
   afterAll(async () => {
@@ -70,6 +92,72 @@ describe('stream router', () => {
       const stream = await server.db.Streams.findOne({ createdBy: host.id });
 
       expect(res.body.streamId).toEqual(String(stream._id));
+    });
+  });
+
+  describe('DELETE /', () => {
+    it('should error if not logged in', async () => {
+      server.logout();
+      const res = await server.exec.delete('/api/stream/');
+      expect(res.status).toBe(401);
+    });
+
+    it('should error if the user is not a host', async () => {
+      server.login(viewer);
+      const res = await server.exec.post('/api/stream');
+      expect(res.status).toBe(403);
+    });
+
+    it('should error if params is not an ObjectId', async () => {
+      server.login(host);
+      const res = await server.exec.delete('/api/stream/1234');
+      expect(res.status).toBe(400);
+    });
+
+    it('should return status 204, and delete the stream from the db', async () => {
+      server.login(host);
+      const stream = await server.db.Streams.insertOne({
+        arn: 'arn_123',
+        createdBy: host.id,
+      });
+      const res = await server.exec.delete(`/api/stream/${stream.insertedId}`);
+
+      const notFoundStream = await server.db.Streams.findOne({ _id: stream.insertedId });
+
+      expect(res.status).toBe(204);
+      expect(notFoundStream).toBeFalsy();
+    });
+  });
+
+  describe('GET /', () => {
+    it('should error if not logged in', async () => {
+      server.logout();
+      const res = await server.exec.get('/api/stream/');
+      expect(res.status).toBe(401);
+    });
+
+    it ('should error if param is not an ObjectId', async () => {
+      server.login(host);
+      const res = await server.exec.get('/api/stream/1234');
+      expect(res.status).toBe(400);
+    });
+
+    it ('should error if channel cannot be found', async () => {
+      server.login(host);
+      const res = await server.exec.get(`/api/stream/${new ObjectId()}`);
+      expect(res.status).toBe(404);
+    });
+
+    it('should return the channel playbackUrl', async () => {
+      server.login(host);
+      const stream = await server.db.Streams.insertOne({
+        arn: '1234',
+        createdBy: 'Matt',
+      });
+      const res = await server.exec.get(`/api/stream/${stream.insertedId}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.playbackUrl).toBe(mockedGetStreamResponse.channel.channel.playbackUrl);
     });
   });
 });

--- a/server/lib/auth.ts
+++ b/server/lib/auth.ts
@@ -1,6 +1,8 @@
 import DiscordOauth2 from 'discord-oauth2';
 import jwt from 'jsonwebtoken';
 
+import { User } from 'shared/user';
+
 export function validateToken(token: string) {
   let valid;
   try {
@@ -30,4 +32,8 @@ export async function getDiscordUserAndGuilds(authCode: string) {
   ]);
 
   return { user, guilds };
+}
+
+export function createUserToken(user: User) {
+  return jwt.sign(user, process.env.AUTH_SECRET, { expiresIn: '7d' });
 }

--- a/server/lib/db.ts
+++ b/server/lib/db.ts
@@ -2,12 +2,12 @@ import { MongoClient } from 'mongodb';
 
 import log from './log';
 
-interface AllowedHost extends Document {
+interface AllowedHost {
   discordId: string;
   username: string;
 }
 
-interface Stream extends Document {
+interface Stream {
   arn: string;
   createdBy: string;
 }
@@ -45,5 +45,3 @@ export class Database {
 const Db = new Database();
 
 export default Db;
-
-

--- a/server/middleware/isAuthed.ts
+++ b/server/middleware/isAuthed.ts
@@ -1,9 +1,8 @@
 import { RequestHandler } from 'express';
-import { UnauthorizedError } from 'express-response-errors';
+import { ForbiddenError, UnauthorizedError } from 'express-response-errors';
 import jwt from 'jsonwebtoken';
 
 import { validateToken } from 'server/lib/auth';
-import Db from 'server/lib/db';
 import { AUTH_COOKIE_NAME } from 'shared/constants';
 import { User } from 'shared/user';
 
@@ -32,10 +31,10 @@ export const isAuthed = (isPage = false): RequestHandler => (req, res, next) => 
 //middleware for creating and deleting streams
 //checks if user's id is in list of allowed host ids in database
 export const isHost = (isPage = false): RequestHandler => async (req, res, next) => {
-  const user = req.user!;
+  const user = req.user;
 
-  const found = await Db.AllowedHosts.findOne({
-    discordId: user.id,
+  const found = await req.db.AllowedHosts.findOne({
+    discordId: user?.id,
   });
 
   if (!found) {
@@ -43,7 +42,7 @@ export const isHost = (isPage = false): RequestHandler => async (req, res, next)
       res.redirect('/');
       return;
     } else {
-      throw new UnauthorizedError('Only hosts can access this resource');
+      throw new ForbiddenError('Only hosts can access this resource');
     }
   }
 

--- a/server/middleware/validateMongoObjectId.ts
+++ b/server/middleware/validateMongoObjectId.ts
@@ -1,0 +1,16 @@
+import { RequestHandler } from 'express';
+import { BadRequestError } from 'express-response-errors';
+import { ObjectId } from 'mongodb';
+
+export const validateMongoObjectId = (
+  location: 'params' | 'body' | 'query',
+  fieldName: string,
+): RequestHandler => async (req, res, next) => {
+  try {
+    new ObjectId(req[location][fieldName]);
+  } catch (err) {
+    throw new BadRequestError('Invalid ID');
+  }
+
+  next();
+};

--- a/server/server.ts
+++ b/server/server.ts
@@ -50,6 +50,15 @@ class Server {
     this.app.use(responseErrorHandler);
   }
 
+  // attaches database to this specific server instance
+  // this way, test DBs are never confused with 'real' DBs
+  setDatabaseOnReq() {
+    this.app.use((req, res, next) => {
+      req.db = this.db;
+      next();
+    });
+  }
+
   async init() {
     this.db = Db;
     const results = await Promise.all([ // Wait for everything in promise to be done
@@ -59,6 +68,7 @@ class Server {
     this.nextApp = results[0];
 
     this.setMiddleware();
+    this.setDatabaseOnReq();
     this.setApiRoutes();
     this.setPageRoutes();
     this.setNextRoutes();

--- a/server/test/server.ts
+++ b/server/test/server.ts
@@ -2,15 +2,36 @@ import 'dotenv-flow/config';
 import { getPortPromise as getPort } from 'portfinder';
 import supertest from 'supertest';
 
+import { createUserToken } from 'server/lib/auth';
 import { Database } from 'server/lib/db';
 import Server from 'server/server';
+import { AUTH_COOKIE_NAME } from 'shared/constants';
+import { User } from 'shared/user';
 
 class TestServer extends Server {
-  async init() {
-    this.db = new Database('test');
+  loggedInUser: User | null;
+
+  async init(testName = 'default') {
+    this.db = new Database(`test-${testName}`);
 
     await this.db.connect();
+    await this.db.db.dropDatabase();
     this.setMiddleware();
+    this.setDatabaseOnReq();
+
+    this.app.use((req, res, next) => {
+      if (this.loggedInUser) {
+        //simulate logged in user by creating a jwt
+        const token = createUserToken(this.loggedInUser);
+        req.cookies[AUTH_COOKIE_NAME] = token;
+      } else {
+        //simulate non-logged-in user by making sure there is no jwt
+        res.clearCookie(AUTH_COOKIE_NAME);
+      }
+
+      next();
+    });
+
     this.setApiRoutes();
     this.setErrorHandler();
 
@@ -27,6 +48,14 @@ class TestServer extends Server {
     return new Promise<void>((resolve) => {
       this.server.close(() => resolve());
     });
+  }
+
+  login(user: User) {
+    this.loggedInUser = user;
+  }
+
+  logout() {
+    this.loggedInUser = null;
   }
 }
 

--- a/server/test/server.ts
+++ b/server/test/server.ts
@@ -11,11 +11,18 @@ import { User } from 'shared/user';
 class TestServer extends Server {
   loggedInUser: User | null;
 
+  async clearDb() {
+    await Promise.all([
+      this.db.AllowedHosts.deleteMany({}),
+      this.db.Streams.deleteMany({}),
+    ]);
+  }
+
   async init(testName = 'default') {
     this.db = new Database(`test-${testName}`);
 
     await this.db.connect();
-    await this.db.db.dropDatabase();
+    await this.clearDb();
     this.setMiddleware();
     this.setDatabaseOnReq();
 

--- a/server/typings/express.d.ts
+++ b/server/typings/express.d.ts
@@ -4,6 +4,7 @@ declare global {
   namespace Express {
     export interface Request {
       user?: User;
+      db: Database;
     }
   }
 }

--- a/server/typings/express.d.ts
+++ b/server/typings/express.d.ts
@@ -1,3 +1,4 @@
+import { Database } from 'server/lib/db';
 import { User } from 'shared/user';
 
 declare global {


### PR DESCRIPTION
Refactors:
* Attaches database to every request (this allows our apps to use databases associated with the server, rather than use a global database - useful for tests)
* Allows logging in/logging out of test server
* Drops test databases whenever the test suite is run

Adds:
* Acceptance tests for the `POST /api/stream` endpoint
