### PR TITLE
delete stream deletes by creator id

### DIFF
--- a/server/api/stream/index.ts
+++ b/server/api/stream/index.ts
@@ -12,6 +12,6 @@ streamRouter.use(isAuthed());
 // (which is descriptive enough)
 streamRouter.post('/', isHost(), postStream);
 streamRouter.get('/:id', validateMongoObjectId('params', 'id'), getStream);
-streamRouter.delete('/:id', validateMongoObjectId('params', 'id'), isHost(), deleteStream);
+streamRouter.delete('/', isHost(), deleteStream);
 
 export default streamRouter;

--- a/server/api/stream/stream.controller.ts
+++ b/server/api/stream/stream.controller.ts
@@ -38,10 +38,14 @@ export const getStream: RequestHandler = async (req, res) => {
 };
 
 export const deleteStream: RequestHandler = async (req, res) => {
-  const stream = await req.db.Streams.findOne({ _id:  new ObjectId(req.params.id) });
+  const stream = await req.db.Streams.findOne({ createdBy: req.user.id });
+
+  if (!stream) {
+    throw new BadRequestError('There is no active stream');
+  }
 
   await endStream(stream.arn);
-  await req.db.Streams.findOneAndDelete({ _id: new ObjectId(req.params.id) });
+  await req.db.Streams.findOneAndDelete({ _id: stream._id });
 
   res.status(204);
 };

--- a/server/api/stream/stream.test.ts
+++ b/server/api/stream/stream.test.ts
@@ -125,7 +125,7 @@ describe('stream router', () => {
       expect(res.status).toBe(403);
     });
 
-    it('should error there is no active stream', async () => {
+    it('should error if there is no active stream', async () => {
       server.login(host);
       const res = await server.exec.delete('/api/stream/');
       expect(res.status).toBe(400);

--- a/server/api/stream/stream.test.ts
+++ b/server/api/stream/stream.test.ts
@@ -121,13 +121,13 @@ describe('stream router', () => {
 
     it('should error if the user is not a host', async () => {
       server.login(viewer);
-      const res = await server.exec.post('/api/stream');
+      const res = await server.exec.delete('/api/stream');
       expect(res.status).toBe(403);
     });
 
-    it('should error if params is not an ObjectId', async () => {
+    it('should error there is no active stream', async () => {
       server.login(host);
-      const res = await server.exec.delete('/api/stream/1234');
+      const res = await server.exec.delete('/api/stream/');
       expect(res.status).toBe(400);
     });
 
@@ -137,7 +137,7 @@ describe('stream router', () => {
         arn: 'arn_123',
         createdBy: host.id,
       });
-      const res = await server.exec.delete(`/api/stream/${stream.insertedId}`);
+      const res = await server.exec.delete('/api/stream/');
 
       const notFoundStream = await server.db.Streams.findOne({ _id: stream.insertedId });
 
@@ -153,13 +153,13 @@ describe('stream router', () => {
       expect(res.status).toBe(401);
     });
 
-    it ('should error if param is not an ObjectId', async () => {
+    it('should error if param is not an ObjectId', async () => {
       server.login(host);
       const res = await server.exec.get('/api/stream/1234');
       expect(res.status).toBe(400);
     });
 
-    it ('should error if channel cannot be found', async () => {
+    it('should error if channel cannot be found', async () => {
       server.login(host);
       const res = await server.exec.get(`/api/stream/${new ObjectId()}`);
       expect(res.status).toBe(404);


### PR DESCRIPTION
Since we are making the assumption that each host can only have a single active stream at a time, ending the stream shouldn't require an ID, since we can find the stream document based on the creator ID